### PR TITLE
30 seconds will be enough for all.

### DIFF
--- a/fpm-prestashop.conf
+++ b/fpm-prestashop.conf
@@ -157,8 +157,8 @@
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             fastcgi_buffers 8 256k;
             fastcgi_buffer_size 256k;
-            fastcgi_send_timeout 300;
-            fastcgi_read_timeout 300;
+            fastcgi_send_timeout 30;
+            fastcgi_read_timeout 30;
             include fastcgi_params;
             fastcgi_index index.php;
             fastcgi_pass php;


### PR DESCRIPTION
Lower timeouts is better to avoid stalled connections.